### PR TITLE
fix: change default max cpu to 24

### DIFF
--- a/vendor/github.com/hyperhq/runv/hypervisor/constants.go
+++ b/vendor/github.com/hyperhq/runv/hypervisor/constants.go
@@ -11,7 +11,7 @@ const (
 	DetachKeys      = "ctrl-p,ctrl-q"
 
 	// cpu/mem hotplug constants
-	DefaultMaxCpus = 8     // CONFIG_NR_CPUS hyperstart.git/build/kernel_config
+	DefaultMaxCpus = 24     // CONFIG_NR_CPUS hyperstart.git/build/kernel_config
 	DefaultMaxMem  = 32768 // size in MiB
 )
 


### PR DESCRIPTION
change default max cpu to 24
`CONFIG_NR_CPUS` for kernel has been changed to 64 recently, we can just build with their latest code.
https://github.com/hyperhq/hyperstart/blob/master/build/arch/x86_64/kernel_config#L441

Will build this internally later on